### PR TITLE
In Github Actions workflows, reference the node version from package.json 

### DIFF
--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -29,7 +29,9 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
     - name: Install dependencies
       working-directory: ./frontend
       # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.

--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -22,21 +22,21 @@ jobs:
   build-storybook-main:
     name: Storybook (main branch)
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout local code to establish repo
-      uses: actions/checkout@v3.5.2
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+    - name: Checkout code
+      uses: actions/checkout@v4
       with:
-        node-version-file: 'frontend/package.json'
-        cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
+        fetch-depth: 0
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Install dependencies
+      working-directory: ./frontend
+      # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
+      run: npm ci
     - name: Build Storybook for main branch
       working-directory: frontend
       run: | # Install npm packages and build the Storybook files
-        npm install
         npm run build-storybook -- --docs -o storybook_static
 
     - name: Deploy 🚀

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -33,7 +33,6 @@ jobs:
           node-version: 20
       - name: Install dependencies
         working-directory: ./frontend
-        # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
         run: npm ci
       - name: Run Chromatic
         id: run_chromatic

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -30,9 +30,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         working-directory: ./frontend
+        # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
         run: npm ci
       - name: Run Chromatic
         id: run_chromatic

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version-file: './frontend/package.json'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -27,7 +27,7 @@ jobs:
       branch_name: ${{ steps.get-branch-name.outputs.branch_name }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
         token: ${{ github.token }}
@@ -62,14 +62,14 @@ jobs:
         echo "branch_name=${{needs.get-pr-num.outputs.branch_name}}"
 
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.get-pr-num.outputs.branch_name }}
         fetch-depth: 1
         token: ${{ github.token }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -71,10 +71,10 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
-
+          node-version-file: './frontend/package.json'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+  
     - name: Install dependencies
       working-directory: ./frontend
       run: npm ci

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -27,7 +27,7 @@ jobs:
       branch_name: ${{ steps.get-branch-name.outputs.branch_name }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
         token: ${{ github.token }}
@@ -62,14 +62,14 @@ jobs:
         echo "branch_name=${{needs.get-pr-num.outputs.branch_name}}"
 
     - name: Checkout repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.get-pr-num.outputs.branch_name }}
         fetch-depth: 0
         token: ${{ github.token }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'
@@ -77,7 +77,6 @@ jobs:
 
     - name: Install dependencies
       working-directory: ./frontend
-        # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
       run: npm ci
     - name: Run Chromatic
       id: run_chromatic


### PR DESCRIPTION
In this PR, we update the Github Actions workflows to pull the node version from the package.json instead of hard coding it as 20.

This will make it easier to update the node version in one place rather than having multiple places it has to be updated.